### PR TITLE
Flash images

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,9 +1,11 @@
 # This is the list of project specific vocabulary for the spellchecker
 
+acat
 adapter
 adapters
 Allwinner
 ASSY
+aunpack
 autoboot
 Bootloader
 bootloader
@@ -22,6 +24,8 @@ GX
 HiFive
 init
 JTAG
+inotify
+inotifywait
 libcamera
 LicheeRV
 macOS
@@ -44,6 +48,7 @@ SiFive
 SPI
 SSD
 StarFive
+sudo
 TTL
 ttyUSB
 UART

--- a/conf.py
+++ b/conf.py
@@ -204,7 +204,7 @@ rst_epilog = '''
 
 # If you are using the :manpage: role, set this variable to the URL for the version
 # that you want to link to:
-# manpages_url = "https://manpages.ubuntu.com/manpages/noble/en/man{section}/{page}.{section}.html"
+manpages_url = "https://manpages.ubuntu.com/manpages/noble/en/man{section}/{page}.{section}.html"
 
 ############################################################
 ### Additional configuration

--- a/how-to/flash-images.rst
+++ b/how-to/flash-images.rst
@@ -1,3 +1,137 @@
 ==============================
 Flash images to a microSD card
 ==============================
+
+Several popular tools exist for flashing images to microSD cards, but this
+guide uses only basic command line tools (specifically :manpage:`dd(1)`),
+ensuring it can be followed even on console-only systems.
+
+The most dangerous aspect of writing images in this manner is ensuring you are
+overwriting the correct device. With root authority, ``dd`` will happily
+overwrite any device you point it at, including the device holding your root
+file-system! To avoid this, we will use inotify-tools to detect the device node
+representing our microSD card.
+
+
+Procedure
+=========
+
+#. Install the pre-requisite packages we're going to be using:
+
+   .. code-block:: text
+
+       sudo apt install inotify-tools atool wget
+
+#. Download the image you wish to write. Here we'll be using the Ubuntu 24.04
+   Server for Raspberry Pi image, but you should substitute your
+   cdimage.ubuntu.com URL here:
+
+   .. code-block:: text
+
+       wget http://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-arm64+raspi.img.xz
+
+#. If you wish to verify the download, also get the :file:`SHA256SUMS` file
+   from the same path, and use it to verify the downloaded file:
+
+   .. code-block:: text
+
+       wget http://cdimage.ubuntu.com/releases/24.04/release/SHA256SUMS
+       sha256sum --ignore-missing --check SHA256SUMS
+
+#. Start with your target microSD card disconnected from your machine
+
+#. Start :manpage:`inotifywait(1)`, watching for new device nodes under
+   :file:`/dev`:
+
+   .. code-block:: text
+
+       inotifywait --event create --format "%w%f" /dev
+
+#. Plug your microSD card into your machine
+
+#. At this point, ``inotifywait`` should exit, displaying the name of a new
+   node under :file:`/dev`. For example:
+
+   .. code-block:: console
+
+       $ inotifywait --event create --format "%w%f" /dev
+       Setting up watches.
+       Watches established.
+       /dev/sda1
+
+   It is likely that the node printed will be a device representing a
+   *partition* of the microSD card, rather than the whole microSD card itself.
+   In the example above, we see "/dev/sda1". This is the first partition of
+   "/dev/sda", which is the device representing the entire microSD card
+
+#. We're now ready to write the image to the microSD card. If the image you
+   downloaded is compressed (indicated by a ".gz", ".bz2", ".xz", or ".zst"
+   suffix on the filename) we cannot write it directly. We'll use the
+   :manpage:`aunpack(1)` command to extract the image, then write the result
+   to the microSD device with :manpage:`dd(1)`:
+
+   .. code-block:: text
+
+       aunpack ubuntu-24.04-preinstalled-server-arm64+raspi.img.xz
+       sudo dd \
+           if=ubuntu-24.04-preinstalled-server-arm64+raspi.img \
+           of=/dev/sdX \
+           bs=16M status=progress
+
+   .. warning::
+
+       Take care to specify the correct output device after the ``of=``
+       parameter. Bear in mind this should be the device covering the entire
+       microSD card, not just a partition.
+
+   .. note::
+
+       We are using :manpage:`sudo(1)` because ``dd`` requires root authority
+       to write to the microSD card device. You will be prompted for your
+       user's password before the write begins (assuming a typical sudo
+       configuration).
+
+#. Once ``dd`` has completed, run :manpage:`sync(1)` just to be reasonably
+   certain that everything is flushed:
+
+   .. code-block:: text
+
+       sudo sync
+
+#. Congratulations! You can remove the microSD card and insert it in your
+   target board
+
+
+Alternate device names
+======================
+
+In some cases, depending on the microSD interface in use, you may see output
+like the following from ``inotifywait``:
+
+.. code-block:: console
+
+    $ inotifywait --event create --format "%w%f" /dev
+    Setting up watches.
+    Watches established.
+    /dev/mmcblk0p1
+
+In this case, we are also seeing a device representation the first partition of
+the microSD card, "/dev/mmcblk0p1". However, here we need to remove the "p1"
+suffix; the device representing the entire microSD card is "/dev/mmcblk0".
+
+This is often the case where the microSD interface is built into your machine
+(e.g. the microSD card slot on a Raspberry Pi), or where the interface is
+connected by something other than USB.
+
+
+Avoiding decompression
+======================
+
+If you have limited disk space and do not wish to unpack the OS image, you can
+decompress the image on the fly and pipe the result to ``dd``. For this, use
+the :manpage:`acat(1)` command. For example:
+
+.. code-block:: text
+
+    acat ubuntu-24.04-preinstalled-server-arm64+raspi.img.xz | \
+        sudo dd of=/dev/sdX bs=16M status=progress

--- a/how-to/flash-images.rst
+++ b/how-to/flash-images.rst
@@ -24,7 +24,7 @@ Procedure
 
 #. Download the image you wish to write. Here we'll be using the Ubuntu 24.04
    Server for Raspberry Pi image, but you should substitute your
-   cdimage.ubuntu.com URL here:
+   ``cdimage.ubuntu.com`` URL here:
 
    .. code-block:: text
 
@@ -61,14 +61,15 @@ Procedure
 
    It is likely that the node printed will be a device representing a
    *partition* of the microSD card, rather than the whole microSD card itself.
-   In the example above, we see "/dev/sda1". This is the first partition of
-   "/dev/sda", which is the device representing the entire microSD card
+   In the example above, we see :file:`/dev/sda1`. This is the first partition
+   of :file:`/dev/sda`, which is the device representing the entire microSD
+   card
 
 #. We're now ready to write the image to the microSD card. If the image you
-   downloaded is compressed (indicated by a ".gz", ".bz2", ".xz", or ".zst"
-   suffix on the filename) we cannot write it directly. We'll use the
-   :manpage:`aunpack(1)` command to extract the image, then write the result
-   to the microSD device with :manpage:`dd(1)`:
+   downloaded is compressed (indicated by a :file:`.gz`, :file:`.bz2`,
+   :file:`.xz`, or :file:`.zst` suffix on the filename) we cannot write it
+   directly. We'll use the :manpage:`aunpack(1)` command to extract the image,
+   then write the result to the microSD device with :manpage:`dd(1)`:
 
    .. code-block:: text
 
@@ -91,8 +92,8 @@ Procedure
        user's password before the write begins (assuming a typical sudo
        configuration).
 
-#. Once ``dd`` has completed, run :manpage:`sync(1)` just to be reasonably
-   certain that everything is flushed:
+#. Once :command:`dd` has completed, run :manpage:`sync(1)` just to be
+   reasonably certain that everything is flushed:
 
    .. code-block:: text
 
@@ -106,7 +107,7 @@ Alternate device names
 ======================
 
 In some cases, depending on the microSD interface in use, you may see output
-like the following from ``inotifywait``:
+like the following from :command:`inotifywait`:
 
 .. code-block:: console
 
@@ -116,8 +117,9 @@ like the following from ``inotifywait``:
     /dev/mmcblk0p1
 
 In this case, we are also seeing a device representation the first partition of
-the microSD card, "/dev/mmcblk0p1". However, here we need to remove the "p1"
-suffix; the device representing the entire microSD card is "/dev/mmcblk0".
+the microSD card, :file:`/dev/mmcblk0p1`. However, here we need to remove the
+"p1" suffix; the device representing the entire microSD card is
+:file:`/dev/mmcblk0`.
 
 This is often the case where the microSD interface is built into your machine
 (e.g. the microSD card slot on a Raspberry Pi), or where the interface is
@@ -128,8 +130,8 @@ Avoiding decompression
 ======================
 
 If you have limited disk space and do not wish to unpack the OS image, you can
-decompress the image on the fly and pipe the result to ``dd``. For this, use
-the :manpage:`acat(1)` command. For example:
+decompress the image on the fly and pipe the result to :command:`dd`. For this,
+use the :manpage:`acat(1)` command. For example:
 
 .. code-block:: text
 

--- a/how-to/flash-images.rst
+++ b/how-to/flash-images.rst
@@ -16,6 +16,8 @@ representing our microSD card.
 Procedure
 =========
 
+#. Start with your target microSD card disconnected from your machine
+
 #. Install the pre-requisite packages we're going to be using:
 
    .. code-block:: text
@@ -38,8 +40,6 @@ Procedure
        wget http://cdimage.ubuntu.com/releases/24.04/release/SHA256SUMS
        sha256sum --ignore-missing --check SHA256SUMS
 
-#. Start with your target microSD card disconnected from your machine
-
 #. Start :manpage:`inotifywait(1)`, watching for new device nodes under
    :file:`/dev`:
 
@@ -47,10 +47,9 @@ Procedure
 
        inotifywait --event create --format "%w%f" /dev
 
-#. Plug your microSD card into your machine
-
-#. At this point, ``inotifywait`` should exit, displaying the name of a new
-   node under :file:`/dev`. For example:
+#. Plug your microSD card into your machine. At this point, ``inotifywait``
+   should exit, displaying the name of a new node under :file:`/dev`. For
+   example:
 
    .. code-block:: console
 
@@ -63,7 +62,7 @@ Procedure
    *partition* of the microSD card, rather than the whole microSD card itself.
    In the example above, we see :file:`/dev/sda1`. This is the first partition
    of :file:`/dev/sda`, which is the device representing the entire microSD
-   card
+   card.
 
 #. We're now ready to write the image to the microSD card. If the image you
    downloaded is compressed (indicated by a :file:`.gz`, :file:`.bz2`,
@@ -92,15 +91,14 @@ Procedure
        user's password before the write begins (assuming a typical sudo
        configuration).
 
-#. Once :command:`dd` has completed, run :manpage:`sync(1)` just to be
+#. Once :command:`dd` has completed, run :manpage:`sync(1)` to be
    reasonably certain that everything is flushed:
 
    .. code-block:: text
 
        sudo sync
 
-#. Congratulations! You can remove the microSD card and insert it in your
-   target board
+#. You can remove the microSD card and insert it into your target board
 
 
 Alternate device names
@@ -116,9 +114,9 @@ like the following from :command:`inotifywait`:
     Watches established.
     /dev/mmcblk0p1
 
-In this case, we are also seeing a device representation the first partition of
+In this case, we are also seeing a device representing the first partition of
 the microSD card, :file:`/dev/mmcblk0p1`. However, here we need to remove the
-"p1" suffix; the device representing the entire microSD card is
+``p1`` suffix; the device representing the entire microSD card is
 :file:`/dev/mmcblk0`.
 
 This is often the case where the microSD interface is built into your machine

--- a/how-to/flash-images.rst
+++ b/how-to/flash-images.rst
@@ -87,7 +87,7 @@ Procedure
 
    .. note::
 
-       We are using :manpage:`sudo(1)` because ``dd`` requires root authority
+       We are using :manpage:`sudo(8)` because ``dd`` requires root authority
        to write to the microSD card device. You will be prompted for your
        user's password before the write begins (assuming a typical sudo
        configuration).


### PR DESCRIPTION
First stab at the "flashing images" how-to. I've deliberately avoided all GUI tools here, as I'd like this to be useable in just about all circumstances (console only, minimal systems, only relying on tools from the archive).

I'm relying on some slightly esoteric tooling (inotifywait) to try and avoid the most dangerous pitfalls of flashing the wrong device. This approach has always worked well for me on PCs and Pis, but please feel free to suggest something better!

I'm also using atool to avoid having to specify all the different "un" commands (gunzip, unxz, bunzip2, etc). Possibly unnecessary, but this is an attempt to minimize the branches in the instructions, thus keeping them simpler.