### PR TITLE
how-to/starfive-visionfive: correct typo ppa

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -52,7 +52,6 @@ PCIe
 picocom
 Polarfire
 poweroff
-ppa
 PPA
 qemu
 QEMU

--- a/how-to/starfive-visionfive.rst
+++ b/how-to/starfive-visionfive.rst
@@ -65,7 +65,7 @@ Either reboot or execute the following commands to apply the configuration:
 Bluetooth
 =========
 
-The firmware required to use Bluetooth is only available in a ppa:
+The firmware required to use Bluetooth is only available in a PPA:
 
 #. Add the RISC-V PPA:
 


### PR DESCRIPTION
* Replace %s/ppa/PPA/
* Remove ppa from .custom_wordlist.txt

https://ubuntu.com/landscape/docs/explanation-PPA uses the capitalized form.