### PR TITLE
how-to: required kernel modules for Allwinner D1 boards

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -38,6 +38,7 @@ HiFive
 HSS
 https
 init
+initramfs
 inotify
 inotifywait
 JTAG
@@ -48,6 +49,7 @@ licheerv
 macOS
 Mantic
 microSD
+mmc
 MSEL
 MultiMediaCard
 netplan
@@ -80,11 +82,13 @@ SPI
 SSD
 StarFive
 sudo
+sunxi
 TTL
 ttyUSB
 UART
 UARTs
 ubuntu
 UEFI
+usr
 VisionFive
 wifi

--- a/how-to/allwinner-nezha-d1.rst
+++ b/how-to/allwinner-nezha-d1.rst
@@ -92,6 +92,16 @@ Limitations
 
 * Shutdown fails.
 
+* The following kernel modules are used for reading from the SD card:
+
+  * mmc-block
+
+  * sunxi-mmc
+
+  They must either be built into the kernel or must be included in the initial
+  RAM disk via /etc/initramfs-tools/modules or via a file in
+  /usr/share/initramfs-tools/modules.d/.
+
 
 .. _Nezha D1: https://d1.docs.aw-ol.com/en/d1_dev/
 .. _cloud-init: https://cloudinit.readthedocs.io/

--- a/how-to/licheerv-dock.rst
+++ b/how-to/licheerv-dock.rst
@@ -95,5 +95,15 @@ Limitations
 
 * Microphone does not work
 
+* The following kernel modules are used for reading from the SD card:
+
+  * mmc-block
+
+  * sunxi-mmc
+
+  They must either be built into the kernel or must be included in the initial
+  RAM disk via /etc/initramfs-tools/modules or via a file in
+  /usr/share/initramfs-tools/modules.d/.
+
 
 .. _LicheeRV board: https://wiki.sipeed.com/hardware/en/lichee/RV/Dock.html


### PR DESCRIPTION
Mention which kernel modules are required in the initial RAM disk.