### PR TITLE
how-to/microchip-polarfire-icicle: correct title

### DIFF
--- a/how-to/microchip-polarfire-icicle.rst
+++ b/how-to/microchip-polarfire-icicle.rst
@@ -1,6 +1,6 @@
-================================================
-Install Ubuntu on the Microchip Polarfire Icicle
-================================================
+========================================================
+Install Ubuntu on the Microchip Polarfire SoC Icicle Kit
+========================================================
 
 
 FPGA Design


### PR DESCRIPTION
Microchip uses the name "PolarFire SoC FPGA Icicle Kit"

Link: https://www.microchip.com/en-us/development-tool/mpfs-icicle-kit-es