### PR TITLE
conf.py: ignore https://www.gnu.org/software/grub/ linkcheck

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -146,7 +146,8 @@ redirects = {}
 
 # Links to ignore when checking links
 linkcheck_ignore = [
-    'http://127.0.0.1:8000'
+    'http://127.0.0.1:8000',
+    'https://www.gnu.org/software/grub/'
     ]
 
 # Pages on which to ignore anchors

--- a/how-to/microchip-polarfire-icicle.rst
+++ b/how-to/microchip-polarfire-icicle.rst
@@ -15,7 +15,7 @@ Express`_ standalone is bundled with the `Programming and Debug Tools`_.
 
 .. _Hart Software Services: https://github.com/polarfire-soc/hart-software-services/releases
 .. _HSS sources: https://github.com/polarfire-soc/hart-software-services
-.. _FlashPro Express: https://www.microchip.com/en-us/products/fpgas-and-plds/fpga-and-soc-design-tools/programming-and-debug/flashpro-and-flashpro-express
+.. _FlashPro Express: https://www.microchip.com/en-us/products/fpgas-and-plds/fpga-and-soc-design-tools/programming-and-debug/flashpro-express
 .. _Programming and Debug Tools: https://www.microchip.com/en-us/products/fpgas-and-plds/fpga-and-soc-design-tools/programming-and-debug
 
 


### PR DESCRIPTION
https://www.gnu.org/software/grub/ fails in linkcheck though the page is valid