### PR TITLE
how-to/qemu-riscv: fix bugs; fix inconsistence; rm duplicated cloud-init content; refine structure

### DIFF
--- a/how-to/qemu-riscv.rst
+++ b/how-to/qemu-riscv.rst
@@ -112,7 +112,7 @@ Running via U-Boot
 
   .. code-block:: text
 
-      [......] cloud-init[...]: Cloud-init v. ... finished at ...  Up ... seconds
+      [   68.346028] cloud-init[703]: Cloud-init v. 22.2-0ubuntu1~20.04.3 finished at Thu, 22 Sep 2022 11:35:28 +0000. Datasource DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net].  Up 68.26 seconds
 
 * Login with the user *ubuntu* and the default password *ubuntu*; you will be
   asked to choose a new password.


### PR DESCRIPTION
Hello! Thank you all for providing this article. I can run a basic RISC-V machine by reading it.

There are some issues with this article, and I've made some modifications. Please review.

Commit message:

* Overall:
    * All sentences should be ended with a punctuation.
    * All command lines should have a similar structure and arguments to make it easier for learners to discover differences.
    * Other improvements.
* Details:
    * The "cloud-init integration" section has been replaced by the "Cloud-init seed" section since all content in it is covered by the "/how-to/headless-usage" article.
* Tested on:
    * Ubuntu 24.04.
    * Ubuntu 25.04.
    * Ubuntu 25.10-snapshot4.
