### PR TITLE
Update how-to/qemu-riscv.rst

### DIFF
--- a/how-to/qemu-riscv.rst
+++ b/how-to/qemu-riscv.rst
@@ -67,12 +67,14 @@ Running via U-Boot
   .. code-block:: text
 
       qemu-system-riscv64 \
-          -cpu rva23s64 \
-          -machine virt -nographic -m 2048 -smp 4 \
-          -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf \
-          -device virtio-net-device,netdev=eth0 -netdev user,id=eth0 \
-          -device virtio-rng-pci \
-          -drive file=ubuntu-*-preinstalled-server-riscv64.img,format=raw,if=virtio
+        -machine virt -m 4G \
+        -cpu rva23s64 -smp cpus=2 \
+        -nographic \
+        -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf \
+        -netdev user,id=eth0 \
+        -device virtio-net-device,netdev=eth0 \
+        -device virtio-rng-pci \
+        -drive file=ubuntu-*-preinstalled-server-riscv64.img,format=raw,if=virtio
 
   The important options to use are:
 
@@ -125,14 +127,20 @@ EDK II may be used instead of U-Boot to run RISC-V virtual machines.
     sudo apt-get install qemu-efi-riscv64
     cp /usr/share/qemu-efi-riscv64/RISCV_VIRT_VARS.fd .
     /usr/bin/qemu-system-riscv64 \
-      -machine virt,acpi=off -m 4096 -smp 4 -cpu rva23s64 \
+      -machine virt,acpi=off -m 4G \
+      -cpu rva23s64 -smp cpus=2 \
       -nographic \
       -drive if=pflash,format=raw,unit=0,file=/usr/share/qemu-efi-riscv64/RISCV_VIRT_CODE.fd,readonly=on \
       -drive if=pflash,format=raw,unit=1,file=RISCV_VIRT_VARS.fd,readonly=off \
-      -drive file=ubuntu-*-preinstalled-server-riscv64.img,format=raw,if=virtio \
       -netdev user,id=net0 \
       -device virtio-net-device,netdev=net0 \
-      -device virtio-rng-pci
+      -device virtio-rng-pci \
+      -drive file=ubuntu-*-preinstalled-server-riscv64.img,format=raw,if=virtio
+
+.. note::
+
+    RISC-V virtual machines can be boot via device-tree (``acpi=off``) or via
+    ACPI (``acpi=on``). If ACPI is supported, depends on the kernel version.
 
 Cloud-init integration
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -171,13 +179,16 @@ Installing live server image
 
    .. code-block:: text
 
-       qemu-system-riscv64 -cpu rva23s64 -machine virt -m 4G -smp cpus=2 -nographic \
-           -kernel /usr/lib/u-boot/qemu-riscv64_smode/u-boot.bin \
-           -netdev user,id=net0 \
-           -device virtio-net-device,netdev=net0 \
-           -drive file=disk,format=raw,if=virtio \
-           -drive file=ubuntu-*-live-server-riscv64.iso,format=raw,if=virtio \
-           -device virtio-rng-pci
+       qemu-system-riscv64
+         -machine virt -m 4G \
+         -machine virt -m 4096 -smp cpus=2 \
+         -nographic \
+         -kernel /usr/lib/u-boot/qemu-riscv64_smode/u-boot.bin \
+         -netdev user,id=net0 \
+         -device virtio-net-device,netdev=net0 \
+         -device virtio-rng-pci \
+         -drive file=disk,format=raw,if=virtio \
+         -drive file=ubuntu-*-live-server-riscv64.iso,format=raw,if=virtio
 
 #. Follow the installation steps in
    `Ubuntu Server installation tutorial
@@ -199,12 +210,15 @@ To run your installed Ubuntu image use:
 
 .. code-block:: text
 
-    qemu-system-riscv64 -cpu rva23s64 -machine virt -m 4G -smp cpus=2 -nographic \
-        -kernel /usr/lib/u-boot/qemu-riscv64_smode/u-boot.bin \
-        -netdev user,id=net0 \
-        -device virtio-net-device,netdev=net0 \
-        -drive file=disk,format=raw,if=virtio \
-        -device virtio-rng-pci
+    qemu-system-riscv64
+      -cpu rva23s64
+      -machine virt,acpi=off -m 4G -smp cpus=2 \
+      -nographic \
+      -kernel /usr/lib/u-boot/qemu-riscv64_smode/u-boot.bin \
+      -netdev user,id=net0 \
+      -device virtio-net-device,netdev=net0 \
+      -device virtio-rng-pci \
+      -drive file=disk,format=raw,if=virtio
 
 
 Cloud-init seed

--- a/how-to/qemu-riscv.rst
+++ b/how-to/qemu-riscv.rst
@@ -48,7 +48,7 @@ Using the pre-installed server image
 
    .. code-block:: text
 
-       xz -dk ubuntu-24.04.2-preinstalled-server-riscv64.img.xz
+       xz -dk ubuntu-*-preinstalled-server-riscv64.img.xz
 
 
 #. Optionally, if you want a larger disk, you can expand the disk (the
@@ -56,7 +56,7 @@ Using the pre-installed server image
 
    .. code-block:: text
 
-       qemu-img resize -f raw ubuntu-24.04-preinstalled-server-riscv64.img +5G
+       qemu-img resize -f raw ubuntu-*-preinstalled-server-riscv64.img +5G
 
 
 #. Next use u-boot-qemu to boot the virtual machine. A working example with all
@@ -70,7 +70,7 @@ Using the pre-installed server image
            -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf \
            -device virtio-net-device,netdev=eth0 -netdev user,id=eth0 \
            -device virtio-rng-pci \
-           -drive file=ubuntu-24.04.2-preinstalled-server-riscv64.img,format=raw,if=virtio
+           -drive file=ubuntu-*-preinstalled-server-riscv64.img,format=raw,if=virtio
 
 The important options to use are:
    * ``-cpu`` controls the emulated CPU
@@ -118,7 +118,7 @@ EDK II may be used instead of U-Boot to run RISC-V virtual machines.
       -nographic \
       -drive if=pflash,format=raw,unit=0,file=/usr/share/qemu-efi-riscv64/RISCV_VIRT_CODE.fd,readonly=on \
       -drive if=pflash,format=raw,unit=1,file=RISCV_VIRT_VARS.fd,readonly=off \
-      -drive file=ubuntu-24.04.3-preinstalled-server-riscv64.img,format=raw,if=virtio \
+      -drive file=ubuntu-*-preinstalled-server-riscv64.img,format=raw,if=virtio \
       -netdev user,id=net0 \
       -device virtio-net-device,netdev=net0 \
       -device virtio-rng-pci
@@ -165,7 +165,7 @@ Installing live server image
            -netdev user,id=net0 \
            -device virtio-net-device,netdev=net0 \
            -drive file=disk,format=raw,if=virtio \
-           -drive file=ubuntu-24.04.3-live-server-riscv64.iso,format=raw,if=virtio \
+           -drive file=ubuntu-*-live-server-riscv64.iso,format=raw,if=virtio \
            -device virtio-rng-pci
 
 #. Follow the installation steps in

--- a/how-to/qemu-riscv.rst
+++ b/how-to/qemu-riscv.rst
@@ -10,10 +10,10 @@ installed:
 * :lp-pkg:`opensbi` -- OpenSBI implements the RISC-V
   Supervisor Binary Interface (:term:`SBI`).
 
-* ``qemu-system-riscv64`` (from :lp-pkg:`qemu`) -- :term:`QEMU` is used to
+* :lp-pkg:`qemu-system-riscv64 <qemu>` -- :term:`QEMU` is used to
   emulate a RISC-V machine.
 
-* ``u-boot-qemu`` (from :lp-pkg:`u-boot`) -- U-Boot is the firmware
+* :lp-pkg:`u-boot-qemu <u-boot>` -- U-Boot is the firmware
   implementing the :term:`UEFI` :term:`API` and loads :term:`GRUB`
 
 The packages can be installed with the following commands:

--- a/how-to/qemu-riscv.rst
+++ b/how-to/qemu-riscv.rst
@@ -7,7 +7,8 @@ Prerequisites
 To boot a RISC-V virtual machine you will need the following packages
 installed:
 
-* ``opensbi`` -- OpenSBI implements the RISC-V SBI
+* :lp-pkg:`opensbi` -- OpenSBI implements the RISC-V
+  Supervisor Binary Interface (:term:`SBI`).
 
 * ``qemu-system-riscv64`` (from :lp-pkg:`qemu`) -- :term:`QEMU` is used to
   emulate a RISC-V machine.

--- a/how-to/qemu-riscv.rst
+++ b/how-to/qemu-riscv.rst
@@ -5,7 +5,6 @@ Prerequisites
 -------------
 
 To boot a RISC-V virtual machine you will need the following packages
-installed:
 
 * :lp-pkg:`opensbi` -- OpenSBI implements the RISC-V
   Supervisor Binary Interface (:term:`SBI`).
@@ -13,15 +12,22 @@ installed:
 * :lp-pkg:`qemu-system-riscv64 <qemu>` -- :term:`QEMU` is used to
   emulate a RISC-V machine.
 
-* :lp-pkg:`u-boot-qemu <u-boot>` -- U-Boot is the firmware
-  implementing the :term:`UEFI` :term:`API` and loads :term:`GRUB`
+and one of
+
+* :lp-pkg:`qemu-efi-riscv64 <edk2>` -- EDK II is the reference implementation
+  of the :term:`UEFI` :term:`API`.
+
+* :lp-pkg:`u-boot-qemu <u-boot>` -- U-Boot is another firmware. It implements a
+  subset of the UEFI API.
+
+installed.
 
 The packages can be installed with the following commands:
 
 .. code-block:: text
 
     sudo apt update
-    sudo apt install opensbi qemu-system-riscv64 u-boot-qemu
+    sudo apt install opensbi qemu-system-riscv64 qemu-efi-riscv64 u-boot-qemu
 
 
 Using the pre-installed server image


### PR DESCRIPTION
* Add missing link to opensbi package and to SBI term in glossary.
* Mention EDK II installation
* Replace release numbers by a wildcard ('*') in code examples to avoid the necessity of updates after new releases.
* Add "Running via U-Boot" heading
* Use an unordered list.
* Format options in Sphinx style
* Reformat qemu-system-riscv64 commands.
* Use same sequence of parameters everywhere.
* Use same values of cpus and memory everywhere.