### PR TITLE
how-to/qemu-riscv.rst: correct formatting

### DIFF
--- a/how-to/qemu-riscv.rst
+++ b/how-to/qemu-riscv.rst
@@ -109,12 +109,12 @@ Running via U-Boot
 * Watch the serial console output and wait for cloud-init to complete. It will
   show a line with the text 'Cloud-init finished' like:
 
-   .. code-block:: text
+  .. code-block:: text
 
-       [   68.346028] cloud-init[703]: Cloud-init v. 22.2-0ubuntu1~20.04.3 finished at Thu, 22 Sep 2022 11:35:28 +0000. Datasource DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net].  Up 68.26 seconds
+      [   68.346028] cloud-init[703]: Cloud-init v. 22.2-0ubuntu1~20.04.3 finished at Thu, 22 Sep 2022 11:35:28 +0000. Datasource DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net].  Up 68.26 seconds
 
-#. Login with the user *ubuntu* and the default password *ubuntu*; you will be
-   asked to choose a new password
+* Login with the user *ubuntu* and the default password *ubuntu*; you will be
+  asked to choose a new password
 
 Running via EDK II
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
* correct indentation
* change a left over ordered list element to unordered list

Fixes: 9ff11fb1c0d5 ("how-to/qemu-riscv.rst: reformat Using the pre-installed server image")