### PR TITLE
how-to/qemu-riscv: Fix typo, adding back rva23 flag

### DIFF
--- a/how-to/qemu-riscv.rst
+++ b/how-to/qemu-riscv.rst
@@ -181,7 +181,7 @@ Installing live server image
 
        qemu-system-riscv64
          -machine virt -m 4G \
-         -machine virt -m 4096 -smp cpus=2 \
+         -cpu rva23s64 -smp cpus=2 \
          -nographic \
          -kernel /usr/lib/u-boot/qemu-riscv64_smode/u-boot.bin \
          -netdev user,id=net0 \

--- a/how-to/qemu-riscv.rst
+++ b/how-to/qemu-riscv.rst
@@ -179,7 +179,7 @@ Installing live server image
 
    .. code-block:: text
 
-       qemu-system-riscv64
+       qemu-system-riscv64 \
          -machine virt -m 4G \
          -cpu rva23s64 -smp cpus=2 \
          -nographic \


### PR DESCRIPTION
This fixes a little typo on the "Installing server image", whee there were 2 times the "-machine virt" flag and no more "rva23s64" flag